### PR TITLE
add led-to-bcm-pin mapping

### DIFF
--- a/edgepi-leds.html
+++ b/edgepi-leds.html
@@ -3,7 +3,7 @@
         category: 'function',
         color: '#a6bbcf',
         defaults: {
-            name: {value:""}
+            name: {value:"TEST-NODE"}
         },
         inputs:1,
         outputs:1,

--- a/edgepi-leds.js
+++ b/edgepi-leds.js
@@ -1,14 +1,27 @@
 const { Gpio } = require( 'onoff' );
 
+// dict holding LED # : BCM GPIO PIN # pairs
+// Example: '1':'13' maps LEDY C1 to GPIO13 pin
+const ledToPin = {
+    '1':'13', '2':'12'
+};
+
 module.exports = function(RED) {
     function ledTriggerNode(ledNum) {
         RED.nodes.createNode(this, ledNum);
         var node = this;
 
         node.on('input', function(msg) {
-            // build Gpio object at BCMP pin corresponding to LED light number
-            const outpin = new Gpio(Number(msg.payload), 'out');
-            outpin.writeSync(1)
+            // build Gpio object at BCM pin corresponding to LED light number
+            const ledNum = msg.payload;
+            // toggle LED if LED number is valid
+            if (ledNum in ledToPin) {
+                const outpin = new Gpio(Number(ledToPin[msg.payload]), 'out');
+                outpin.writeSync(1)
+            }
+            else {
+                node.error("LED number does not exist");
+            }
             node.send(msg);
         });
     }


### PR DESCRIPTION
Node can now receive LED number and map this to the corresponding GPIO pin.